### PR TITLE
Issue 5: Made requested changes to __init__.py

### DIFF
--- a/geochatt/__init__.py
+++ b/geochatt/__init__.py
@@ -82,6 +82,8 @@ cardinal_directions = {
     "SOUTH": "S", "SOUTHWEST": "SW", "WEST": "W", "NORTHWEST": "NW"
 }
 # Create dictionary that contains all USPS street suffixes and their abbreviations
+# Does not include suffixes that are not abbreviated (i.e., "ROW")
+# Link to information: https://pe.usps.com/text/pub28/28apc_002.htm
 street_suffixes = {
     "ALLEY": "ALY", "ANNEX": "ANX", "ARCADE": "ARC", "AVENUE": "AVE", "BAYOU": "BYU", "BEACH": "BCH", 
     "BEND": "BND", "BLUFF": "BLF", "BLUFFS": "BLFS", "BOTTOM": "BTM", "BOULEVARD": "BLVD", "BRANCH": "BR", 
@@ -92,32 +94,32 @@ street_suffixes = {
     "COVE": "CV", "COVES": "CVS", "CREEK": "CRK", "CRESCENT": "CRES", "CREST": "CRST", "CROSSING": "XING", 
     "CROSSROAD": "XRD", "CROSSROADS": "XRDS", "CURVE": "CURV", "DALE": "DL", "DAM": "DM", "DIVIDE": "DV", 
     "DRIVE": "DR", "DRIVES": "DRS", "ESTATE": "EST", "ESTATES": "ESTS", "EXPRESSWAY": "EXPY", 
-    "EXTENSION": "EXT", "EXTENSIONS": "EXTS", "FALL": "FALL", "FALLS": "FLS", "FERRY": "FRY", "FIELD": "FLD", 
+    "EXTENSION": "EXT", "EXTENSIONS": "EXTS", "FALLS": "FLS", "FERRY": "FRY", "FIELD": "FLD", 
     "FIELDS": "FLDS", "FLAT": "FLT", "FLATS": "FLTS", "FORD": "FRD", "FORDS": "FRDS", "FOREST": "FRST", 
     "FORGE": "FRG", "FORGES": "FRGS", "FORK": "FRK", "FORKS": "FRKS", "FORT": "FT", "FREEWAY": "FWY", 
     "GARDEN": "GDN", "GARDENS": "GDNS", "GATEWAY": "GTWY", "GLEN": "GLN", "GLENS": "GLNS", "GREEN": "GRN", 
     "GREENS": "GRNS", "GROVE": "GRV", "GROVES": "GRVS", "HARBOR": "HBR", "HARBORS": "HBRS", "HAVEN": "HVN", 
     "HEIGHTS": "HTS", "HIGHWAY": "HWY", "HILL": "HL", "HILLS": "HLS", "HOLLOW": "HOLW", "INLET": "INLT", 
-    "ISLAND": "IS", "ISLANDS": "ISS", "ISLE": "ISLE", "JUNCTION": "JCT", "JUNCTIONS": "JCTS", "KEY": "KY", 
-    "KEYS": "KYS", "KNOLL": "KNL", "LAKE": "LK", "LAKES": "LKS", "LAND": "LAND", "LANDING": "LNDG", 
+    "ISLAND": "IS", "ISLANDS": "ISS", "JUNCTION": "JCT", "JUNCTIONS": "JCTS", "KEY": "KY", 
+    "KEYS": "KYS", "KNOLL": "KNL", "LAKE": "LK", "LAKES": "LKS", "LANDING": "LNDG", 
     "LANE": "LN", "LIGHT": "LGT", "LIGHTS": "LGTS", "LOAF": "LF", "LOCK": "LCK", "LOCKS": "LCKS", 
-    "LODGE": "LDG", "LOOP": "LOOP", "MALL": "MALL", "MANOR": "MNR", "MANORS": "MNRS", "MEADOW": "MDW", 
-    "MEADOWS": "MDWS", "MEWS": "MEWS", "MILL": "ML", "MILLS": "MLS", "MISSION": "MSN", "MOTORWAY": "MTWY", 
-    "MOUNT": "MT", "MOUNTAIN": "MTN", "MOUNTAINS": "MTNS", "NECK": "NCK", "ORCHARD": "ORCH", "OVAL": "OVAL", 
-    "OVERPASS": "OPAS", "PARK": "PARK", "PARKS": "PARK", "PARKWAY": "PKWY", "PARKWAYS": "PKWY", 
-    "PASS": "PASS", "PASSAGE": "PSGE", "PATH": "PATH", "PIKE": "PIKE", "PINE": "PNE", "PINES": "PNES", 
+    "LODGE": "LDG", "MANOR": "MNR", "MANORS": "MNRS", "MEADOW": "MDW", 
+    "MEADOWS": "MDWS", "MILL": "ML", "MILLS": "MLS", "MISSION": "MSN", "MOTORWAY": "MTWY", 
+    "MOUNT": "MT", "MOUNTAIN": "MTN", "MOUNTAINS": "MTNS", "NECK": "NCK", "ORCHARD": "ORCH", 
+    "OVERPASS": "OPAS", "PARKS": "PARK", "PARKWAY": "PKWY", "PARKWAYS": "PKWY", 
+    "PASSAGE": "PSGE", "PINE": "PNE", "PINES": "PNES", 
     "PL": "PLACE", "PLAIN": "PLN", "PLAINS": "PLNS", "PLAZA": "PLZ", "POINT": "PT", "POINTS": "PTS", 
-    "PORT": "PRT", "PORTS": "PRTS", "PRAIRIE": "PR", "RADIAL": "RADL", "RAMP": "RAMP", "RANCH": "RNCH", 
+    "PORT": "PRT", "PORTS": "PRTS", "PRAIRIE": "PR", "RADIAL": "RADL", "RANCH": "RNCH", 
     "RAPID": "RPD", "RAPIDS": "RPDS", "REST": "RST", "RIDGE": "RDG", "RIDGES": "RDGS", "RIVER": "RIV", 
-    "ROAD": "RD", "ROADS": "RDS", "ROUTE": "RTE", "ROW": "ROW", "RUE": "RUE", "RUN": "RUN", "SHOAL": "SHL", 
+    "ROAD": "RD", "ROADS": "RDS", "ROUTE": "RTE", "SHOAL": "SHL", 
     "SHOALS": "SHLS", "SHORE": "SHR", "SHORES": "SHRS", "SKYWAY": "SKWY", "SPRING": "SPG", 
-    "SPRINGS": "SPGS", "SPUR": "SPUR", "SPURS": "SPUR", "SQUARE": "SQ", "SQUARES": "SQS", "STATION": "STA", 
+    "SPRINGS": "SPGS", "SPURS": "SPUR", "SQUARE": "SQ", "SQUARES": "SQS", "STATION": "STA", 
     "STRAVENUE": "STRA", "STREAM": "STRM", "STREET": "ST", "STREETS": "STS", "SUMMIT": "SMT", 
     "TERRACE": "TER", "THROUGHWAY": "TRWY", "TRACE": "TRCE", "TRACK": "TRAK", "TRAFFICWAY": "TRFY", 
     "TRAIL": "TRL", "TRAILER": "TRLR", "TUNNEL": "TUNL", "TURNPIKE": "TPKE", "UNDERPASS": "UPAS", 
     "UNION": "UN", "UNIONS": "UNS", "VALLEY": "VLY", "VALLEYS": "VLYS", "VIADUCT": "VIA", "VIEW": "VW", 
-    "VIEWS": "VWS", "VILLAGE": "VLG", "VILLAGES": "VLGS", "VILLE": "VL", "VISTA": "VIS", "WALK": "WALK", 
-    "WALKS": "WALK", "WALL": "WALL", "WAY": "WAY", "WAYS": "WAYS", "WELL": "WL", "WELLS": "WLS"
+    "VIEWS": "VWS", "VILLAGE": "VLG", "VILLAGES": "VLGS", "VILLE": "VL", "VISTA": "VIS", 
+    "WALKS": "WALK", "WELL": "WL", "WELLS": "WLS"
 }
 
 
@@ -133,16 +135,19 @@ def get_parcel(address):
     # Make a list of acceptable address strings - ["EAST 11TH STREET", "E 11TH STREET"], for example
     acceptable = [check_addr]
     # Check the input string for each of the cardinal directions
+    dir_normalized = None
     for dir, abbrev in cardinal_directions.items():
         if dir in check_addr:
             # Replace the first instance of the direction with its abbreviation
             dir_normalized = check_addr.replace(dir, abbrev, 1)
         # If this dir isn't in check_addr and dir_normalized hasn't been set:
-        elif "dir_normalized" not in locals():
+        elif dir_normalized is None:
             # Set it to check_addr for later - will be replaced if some direction is found, else left alone
             dir_normalized = check_addr
     # Check if the working "normalized" string's street suffix is spelled out (Ex: "DRIVE")
-    split_by_word = dir_normalized.split()
+    # Set normalized to dir_normalized for now - if suffix can be abbreviated, this will be replaced
+    normalized = dir_normalized
+    split_by_word = normalized.split()
     for suffix, shorthand in street_suffixes.items():
         if split_by_word[-1] == suffix:
             # Replace the full suffix with the shorthand version (Ex: "DRIVE" -> "DR")

--- a/geochatt/__init__.py
+++ b/geochatt/__init__.py
@@ -76,6 +76,51 @@ def get_address(longitude, latitude, max_distance=0.0001):
         return parcel_strtree["geoms"][nearest_geom]
 
 
+# Create dictionary of cardinal directions that may appear in addresses with their abbreviations
+cardinal_directions = {
+    "NORTH": "N", "NORTHEAST": "NE", "EAST": "E", "SOUTHEAST": "SE", 
+    "SOUTH": "S", "SOUTHWEST": "SW", "WEST": "W", "NORTHWEST": "NW"
+}
+# Create dictionary that contains all USPS street suffixes and their abbreviations
+street_suffixes = {
+    "ALLEY": "ALY", "ANNEX": "ANX", "ARCADE": "ARC", "AVENUE": "AVE", "BAYOU": "BYU", "BEACH": "BCH", 
+    "BEND": "BND", "BLUFF": "BLF", "BLUFFS": "BLFS", "BOTTOM": "BTM", "BOULEVARD": "BLVD", "BRANCH": "BR", 
+    "BRIDGE": "BRG", "BROOK": "BRK", "BROOKS": "BRKS", "BURG": "BG", "BURGS": "BGS", "BYPASS": "BYP", 
+    "CAMP": "CP", "CANYON": "CYN", "CAPE": "CPE", "CAUSEWAY": "CSWY", "CENTER": "CTR", "CENTERS": "CTRS", 
+    "CIRCLE": "CIR", "CIRCLES": "CIRS", "CLIFF": "CLF", "CLIFFS": "CLFS", "CLUB": "CLB", "COMMON": "CMN", 
+    "COMMONS": "CMNS", "CORNER": "COR", "CORNERS": "CORS", "COURSE": "CRSE", "COURT": "CT", "COURTS": "CTS", 
+    "COVE": "CV", "COVES": "CVS", "CREEK": "CRK", "CRESCENT": "CRES", "CREST": "CRST", "CROSSING": "XING", 
+    "CROSSROAD": "XRD", "CROSSROADS": "XRDS", "CURVE": "CURV", "DALE": "DL", "DAM": "DM", "DIVIDE": "DV", 
+    "DRIVE": "DR", "DRIVES": "DRS", "ESTATE": "EST", "ESTATES": "ESTS", "EXPRESSWAY": "EXPY", 
+    "EXTENSION": "EXT", "EXTENSIONS": "EXTS", "FALL": "FALL", "FALLS": "FLS", "FERRY": "FRY", "FIELD": "FLD", 
+    "FIELDS": "FLDS", "FLAT": "FLT", "FLATS": "FLTS", "FORD": "FRD", "FORDS": "FRDS", "FOREST": "FRST", 
+    "FORGE": "FRG", "FORGES": "FRGS", "FORK": "FRK", "FORKS": "FRKS", "FORT": "FT", "FREEWAY": "FWY", 
+    "GARDEN": "GDN", "GARDENS": "GDNS", "GATEWAY": "GTWY", "GLEN": "GLN", "GLENS": "GLNS", "GREEN": "GRN", 
+    "GREENS": "GRNS", "GROVE": "GRV", "GROVES": "GRVS", "HARBOR": "HBR", "HARBORS": "HBRS", "HAVEN": "HVN", 
+    "HEIGHTS": "HTS", "HIGHWAY": "HWY", "HILL": "HL", "HILLS": "HLS", "HOLLOW": "HOLW", "INLET": "INLT", 
+    "ISLAND": "IS", "ISLANDS": "ISS", "ISLE": "ISLE", "JUNCTION": "JCT", "JUNCTIONS": "JCTS", "KEY": "KY", 
+    "KEYS": "KYS", "KNOLL": "KNL", "LAKE": "LK", "LAKES": "LKS", "LAND": "LAND", "LANDING": "LNDG", 
+    "LANE": "LN", "LIGHT": "LGT", "LIGHTS": "LGTS", "LOAF": "LF", "LOCK": "LCK", "LOCKS": "LCKS", 
+    "LODGE": "LDG", "LOOP": "LOOP", "MALL": "MALL", "MANOR": "MNR", "MANORS": "MNRS", "MEADOW": "MDW", 
+    "MEADOWS": "MDWS", "MEWS": "MEWS", "MILL": "ML", "MILLS": "MLS", "MISSION": "MSN", "MOTORWAY": "MTWY", 
+    "MOUNT": "MT", "MOUNTAIN": "MTN", "MOUNTAINS": "MTNS", "NECK": "NCK", "ORCHARD": "ORCH", "OVAL": "OVAL", 
+    "OVERPASS": "OPAS", "PARK": "PARK", "PARKS": "PARK", "PARKWAY": "PKWY", "PARKWAYS": "PKWY", 
+    "PASS": "PASS", "PASSAGE": "PSGE", "PATH": "PATH", "PIKE": "PIKE", "PINE": "PNE", "PINES": "PNES", 
+    "PL": "PLACE", "PLAIN": "PLN", "PLAINS": "PLNS", "PLAZA": "PLZ", "POINT": "PT", "POINTS": "PTS", 
+    "PORT": "PRT", "PORTS": "PRTS", "PRAIRIE": "PR", "RADIAL": "RADL", "RAMP": "RAMP", "RANCH": "RNCH", 
+    "RAPID": "RPD", "RAPIDS": "RPDS", "REST": "RST", "RIDGE": "RDG", "RIDGES": "RDGS", "RIVER": "RIV", 
+    "ROAD": "RD", "ROADS": "RDS", "ROUTE": "RTE", "ROW": "ROW", "RUE": "RUE", "RUN": "RUN", "SHOAL": "SHL", 
+    "SHOALS": "SHLS", "SHORE": "SHR", "SHORES": "SHRS", "SKYWAY": "SKWY", "SPRING": "SPG", 
+    "SPRINGS": "SPGS", "SPUR": "SPUR", "SPURS": "SPUR", "SQUARE": "SQ", "SQUARES": "SQS", "STATION": "STA", 
+    "STRAVENUE": "STRA", "STREAM": "STRM", "STREET": "ST", "STREETS": "STS", "SUMMIT": "SMT", 
+    "TERRACE": "TER", "THROUGHWAY": "TRWY", "TRACE": "TRCE", "TRACK": "TRAK", "TRAFFICWAY": "TRFY", 
+    "TRAIL": "TRL", "TRAILER": "TRLR", "TUNNEL": "TUNL", "TURNPIKE": "TPKE", "UNDERPASS": "UPAS", 
+    "UNION": "UN", "UNIONS": "UNS", "VALLEY": "VLY", "VALLEYS": "VLYS", "VIADUCT": "VIA", "VIEW": "VW", 
+    "VIEWS": "VWS", "VILLAGE": "VLG", "VILLAGES": "VLGS", "VILLE": "VL", "VISTA": "VIS", "WALK": "WALK", 
+    "WALKS": "WALK", "WALL": "WALL", "WAY": "WAY", "WAYS": "WAYS", "WELL": "WL", "WELLS": "WLS"
+}
+
+
 # Description
 # - Returns the geometry of the parcel associated with a given address.
 # Accepts
@@ -83,6 +128,28 @@ def get_address(longitude, latitude, max_distance=0.0001):
 # Returns
 # - parcel: str
 def get_parcel(address):
+    # Convert input to uppercase
+    check_addr = address.upper()
+    # Make a list of acceptable address strings - ["EAST 11TH STREET", "E 11TH STREET"], for example
+    acceptable = [check_addr]
+    # Check the input string for each of the cardinal directions
+    for dir, abbrev in cardinal_directions.items():
+        if dir in check_addr:
+            # Replace the first instance of the direction with its abbreviation
+            dir_normalized = check_addr.replace(dir, abbrev, 1)
+        # If this dir isn't in check_addr and dir_normalized hasn't been set:
+        elif "dir_normalized" not in locals():
+            # Set it to check_addr for later - will be replaced if some direction is found, else left alone
+            dir_normalized = check_addr
+    # Check if the working "normalized" string's street suffix is spelled out (Ex: "DRIVE")
+    split_by_word = dir_normalized.split()
+    for suffix, shorthand in street_suffixes.items():
+        if split_by_word[-1] == suffix:
+            # Replace the full suffix with the shorthand version (Ex: "DRIVE" -> "DR")
+            normalized = dir_normalized.replace(suffix, shorthand, 1)
+    # Append the normalized address string to the "acceptable" list
+    acceptable.append(normalized)
+    # For debugging: print("ACCEPTABLE LIST: ", acceptable)
     # Open the parcel data file
     with gzip.open(
         os.path.join(directory, "live_parcels.csv.gz"), "rt", newline=""
@@ -90,6 +157,6 @@ def get_parcel(address):
         # Read each row and compare its address to the target
         for row in csv.DictReader(f):
             if row["ADDRESS"]:
-                if row["ADDRESS"] == address:
+                if row["ADDRESS"] in acceptable:
                     # Return the target address's parcel geometry
                     return row["geometry"]

--- a/test.py
+++ b/test.py
@@ -6,7 +6,7 @@ import geochatt
 
 class TestCityHall(unittest.TestCase):
     def test_get_parcel(self):
-        result = geochatt.get_parcel(address="101 E 11TH ST")
+        result = geochatt.get_parcel(address="101 east 11th street")
         self.assertEqual(
             result,
             "POLYGON ((-85.3069572 35.043897, -85.3074818 35.0440926, -85.3075952 35.0438743, -85.3078311 35.0434433, -85.3073192 35.0432494, -85.3069718 35.0438707, -85.3069572 35.043897))",


### PR DESCRIPTION
- Suffixes that don't have an abbreviation (i.e., "ROW) have been removed from the street_suffixes dictionary
- A link to the USPS page with the abbreviation information has been added
- Changed dir_normalized so that it is set to None initially, then checked if it holds **no** value to see if **no** direction was found in the first "for" loop, in which case dir_normalized is set to check_addr (raw input converted to uppercase)
- Set normalized to dir_normalized initially, so that if the suffix is **not** found in the search of street_suffixes (meaning the suffix can't be abbreviated), the working address string (same value as dir_normalized) is appended to the "acceptable" list