### PR TITLE
Issue 3: Implemented get_parcel_centroid()

### DIFF
--- a/geochatt/__init__.py
+++ b/geochatt/__init__.py
@@ -165,3 +165,18 @@ def get_parcel(address):
                 if row["ADDRESS"] in acceptable:
                     # Return the target address's parcel geometry
                     return row["geometry"]
+
+
+# Description
+# - Returns the centroid of the parcel located at the input address
+# Accepts
+# - address: str; the street address
+# Returns
+# - centroid: shapely.Point; Point with x (longitude) and y (latitude) coordinates that represents centroid
+def get_parcel_centroid(address):
+    # First, get the parcel's polygon in WKT (string) format
+    parcel = get_parcel(address)
+    # Then, create a Shapely polygon with the output
+    polygon = from_wkt(parcel)
+    # Take Shapely's centroid attribute from the polygon and return it
+    return polygon.centroid

--- a/test.py
+++ b/test.py
@@ -7,7 +7,15 @@ import geochatt
 class TestCityHall(unittest.TestCase):
     def test_get_parcel_centroid(self):
             result = geochatt.get_parcel_centroid(address="101 EAST 11TH ST")
-            print("RESULT OF TEST_GET_PARCEL_CENTROID (101 EAST 11TH ST): ", result)
+            # Please Note: The centroid is printed so that its coordinates can be validated on geojson.io.
+            # Here is a link to the website: https://geojson.io/#map=2/0/20
+            # Go to Chattanooga Municipal Building (address above), click the teardrop-shaped icon on the right,
+            # and click in the middle of the property. The coordinates should be similar--not like a degree off.
+            # print("RESULT OF TEST_GET_PARCEL_CENTROID (101 EAST 11TH ST): ", result)
+            # Test each point to see if results match previous tests
+            # These were the results collected in December of 2024, so changes to shapely could cause them to be unequal
+            self.assertEqual(result.x, -85.30739570641228)
+            self.assertEqual(result.y, 35.0436712625469)
 
     def test_get_parcel(self):
         result = geochatt.get_parcel(address="101 east 11th street")

--- a/test.py
+++ b/test.py
@@ -5,6 +5,10 @@ import geochatt
 
 
 class TestCityHall(unittest.TestCase):
+    def test_get_parcel_centroid(self):
+            result = geochatt.get_parcel_centroid(address="101 EAST 11TH ST")
+            print("RESULT OF TEST_GET_PARCEL_CENTROID (101 EAST 11TH ST): ", result)
+
     def test_get_parcel(self):
         result = geochatt.get_parcel(address="101 east 11th street")
         self.assertEqual(


### PR DESCRIPTION
- get_parcel_centroid() takes an address and returns the centroid of its parcel polygon
- Relies on get_parcel() to retrieve the parcel polygon
- Return value is a Shapely Point object with x and y coordinates
